### PR TITLE
feat: lay some groundwork for our base aws account

### DIFF
--- a/infrastructure/000-aws-base/aws.tf
+++ b/infrastructure/000-aws-base/aws.tf
@@ -1,0 +1,28 @@
+// Default AWS provider is in the region us-east-1 (Viginia)
+provider "aws" {
+  region = "us-east-1"
+}
+
+// Define aliases for other AWS regions
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "us_east_2"
+  region = "us-east-2"
+}
+
+provider "aws" {
+  alias  = "us_west_1"
+  region = "us-west-1"
+}
+
+provider "aws" {
+  alias  = "us_west_2"
+  region = "us-west-2"
+}
+
+// Create a pointer to the caller identity which provides reflective account information
+data "aws_caller_identity" "current" {}

--- a/infrastructure/000-aws-base/kms.tf
+++ b/infrastructure/000-aws-base/kms.tf
@@ -1,0 +1,12 @@
+// A custom, account level KMS key for reuse
+resource "aws_kms_key" "base" {
+  description         = "A base key for use accross the account, nonspecific to an application"
+  enable_key_rotation = true
+  tags                = merge(local.common_tags)
+}
+
+// An alais to our custom KMS key
+resource "aws_kms_alias" "base" {
+  name_prefix   = "alias/base"
+  target_key_id = aws_kms_key.base.key_id
+}

--- a/infrastructure/000-aws-base/locals.tf
+++ b/infrastructure/000-aws-base/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  common_tags = {
+    Application = "Base"
+    Stack       = "000-aws-base"
+    IsTerraform = "true"
+  }
+}

--- a/infrastructure/000-aws-base/outputs.tf
+++ b/infrastructure/000-aws-base/outputs.tf
@@ -1,0 +1,11 @@
+output "kms_alias_name" {
+  value = aws_kms_alias.base.name
+}
+
+output "kms_key_id" {
+  value = aws_kms_key.base.key_id
+}
+
+output "s3_access_logs_s3_bucket_id" {
+  value = aws_s3_bucket.s3_access_logs.id
+}

--- a/infrastructure/000-aws-base/s3.tf
+++ b/infrastructure/000-aws-base/s3.tf
@@ -1,0 +1,15 @@
+// A bucket to use as a log destination bucket for all other buckets
+resource "aws_s3_bucket" "s3_access_logs" {
+  acl           = "log-delivery-write"
+  bucket_prefix = "logs-s3-access"
+  tags          = merge(local.common_tags)
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm     = "aws:kms"
+        kms_master_key_id = aws_kms_key.base.key_id
+      }
+    }
+  }
+}

--- a/infrastructure/000-aws-base/vpc.tf
+++ b/infrastructure/000-aws-base/vpc.tf
@@ -1,0 +1,90 @@
+// Divide the network space for each AWS region.
+// VPCs can only support a /16 sized IPv4 network or a /56 sized IPv6 network
+// We pick different addresses higher than the /16 space to ensure we can easily link the VPCs
+module "vpc_cidrs" {
+  source = "hashicorp/subnets/cidr"
+
+  base_cidr_block = "10.0.0.0/8"
+  networks = [
+    {
+      name     = "us_east_1"
+      new_bits = 8
+    },
+    {
+      name     = "us_east_2"
+      new_bits = 8
+    },
+    {
+      name     = "us_west_1"
+      new_bits = 8
+    },
+    {
+      name     = "us_west_2"
+      new_bits = 8
+    },
+  ]
+}
+
+// Get a list of AZs supported by this region so we can put a subnet in each one
+data "aws_availability_zones" "us_east_1" {
+  provider = aws.us_east_1
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+// Divide the subnets into groups and provide each group with a /18 space CIDR
+module "us_east_1_subnet_group_cidrs" {
+  source = "hashicorp/subnets/cidr"
+
+  base_cidr_block = module.vpc_cidrs.network_cidr_blocks.us_east_1
+  networks = [
+    {
+      name     = "private"
+      new_bits = 2
+    },
+    {
+      name     = "public"
+      new_bits = 2
+    },
+  ]
+}
+
+// Divide the private groups by AZ and provide each with a /22 CIDR
+module "us_east_1_private_subnet_cidrs" {
+  source = "hashicorp/subnets/cidr"
+
+  base_cidr_block = module.us_east_1_subnet_group_cidrs.base_cidr_block
+  networks = [for az_name in sort(data.aws_availability_zones.us_east_1.names) : {name = az_name, new_bits = 4}]
+}
+
+// Divide the public groups by AZ and provide each with a /22 CIDR
+module "us_east_1_public_subnet_cidrs" {
+  source = "hashicorp/subnets/cidr"
+
+  base_cidr_block = module.us_east_1_subnet_group_cidrs.base_cidr_block
+  networks = [for az_name in sort(data.aws_availability_zones.us_east_1.names) : {name = az_name, new_bits = 4}]
+}
+
+module "vpc_us_east_1" {
+  source = "terraform-aws-modules/vpc/aws"
+  providers = {
+    aws = aws.us_east_1
+  }
+
+  name = "base"
+  cidr = module.vpc_cidrs.network_cidr_blocks.us_east_1
+
+  enable_ipv6                     = true
+  assign_ipv6_address_on_creation = true
+
+
+  azs             = sort(data.aws_availability_zones.us_east_1.names)
+  private_subnets = values(module.us_east_1_private_subnet_cidrs.network_cidr_blocks)
+  public_subnets  = values(module.us_east_1_public_subnet_cidrs.network_cidr_blocks)
+
+  enable_nat_gateway = true
+
+  tags = merge(local.common_tags)
+}


### PR DESCRIPTION
## Purpose

This is just a beginning for our terraform setup. Right now I'm laying out what we need for VPC connectivity and S3 logging and trying to position for multi-Region, multi-AZ setup. This will enable proper cloudfront & api gateway connectivity

## What this does

 \* Kinda -- terraform isn't setup yet so no promises that this code works entirely, and there may be some work ahead to modularize it

- Sets up Regions we will work with

(The rest of these are only for us-east-1, but will later be for all regions)

- Build S3 log delivery
- Build A VPC and interconnected network between regions
- Setup Security groups and subnets for each AZ in each region
- Setup a master encryption key

## Project Layout

I'm going to be using the `infrastructure` directory to hold any terraform workspaces. Each workspace will get its own folder, prefixed by 3 numbers like `000-aws-base`. The numbers indicate an order between implicitly dependent resources, without tightly coupling those resources. While most of the time, order won't concern us, there may be cases where recovery and spanning changes must be done in order of the prefix.

Each workspace will be designed to be repeated per environment (production/development, etc)