### PR TITLE
fix: add subnet prefixes to enable ipv6 creation

### DIFF
--- a/infrastructure/000-aws-base/vpc.tf
+++ b/infrastructure/000-aws-base/vpc.tf
@@ -67,6 +67,10 @@ module "us_east_1_public_subnet_cidrs" {
   networks = [for az_name in sort(data.aws_availability_zones.us_east_1.names) : {name = az_name, new_bits = 4}]
 }
 
+locals {
+  subnet_count = length(data.aws_availability_zones.us_east_1.names)
+}
+
 module "vpc_us_east_1" {
   source = "terraform-aws-modules/vpc/aws"
   providers = {
@@ -83,6 +87,9 @@ module "vpc_us_east_1" {
   azs             = sort(data.aws_availability_zones.us_east_1.names)
   private_subnets = values(module.us_east_1_private_subnet_cidrs.network_cidr_blocks)
   public_subnets  = values(module.us_east_1_public_subnet_cidrs.network_cidr_blocks)
+
+  private_subnet_ipv6_prefixes = range(subnet_count)
+  public_subnet_ipv6_prefixes	= range(subnet_count, subnet_count * 2)
 
   enable_nat_gateway = true
 


### PR DESCRIPTION
## Problem

There was an error on creation of the VPC module because the subnets did not have an IPv6 CIDR block assigned but were being set to automatically assign IPv6 addresses.

## Change

Assign an IPv6 CIDR with some CIDR math.