### PR TITLE
feat: split vpc out into new module wrapper

### DIFF
--- a/infrastructure/000-aws-base/modules/vpc/outputs.tf
+++ b/infrastructure/000-aws-base/modules/vpc/outputs.tf
@@ -1,0 +1,3 @@
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}

--- a/infrastructure/000-aws-base/modules/vpc/terraform.tf
+++ b/infrastructure/000-aws-base/modules/vpc/terraform.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.7.0"
+    }
+  }
+}

--- a/infrastructure/000-aws-base/modules/vpc/variables.tf
+++ b/infrastructure/000-aws-base/modules/vpc/variables.tf
@@ -1,0 +1,11 @@
+variable "cidr_block" {
+  default     = "10.0.0.0/16"
+  description = "The CIDR block to use for the VPC. IPv4; max /16"
+  type        = string
+}
+
+variable "tags" {
+  default     = {}
+  description = "Tags applied to the VPC resources"
+  type        = map
+}

--- a/infrastructure/000-aws-base/modules/vpc/vpc.tf
+++ b/infrastructure/000-aws-base/modules/vpc/vpc.tf
@@ -1,0 +1,68 @@
+# Get a list of AZs supported by this region so we can put a subnet in each one
+data "aws_availability_zones" "this" {
+  filter {
+    name = "opt-in-status"
+
+    # This prevents local regions and outposts from being selected
+    values = ["opt-in-not-required"]
+  }
+}
+
+# Divide the subnets into groups and provide each group with a /18 space CIDR
+module "subnet_group_cidrs" {
+  source = "hashicorp/subnets/cidr"
+
+  base_cidr_block = var.cidr_block
+  networks = [
+    {
+      name     = "private"
+      new_bits = 2
+    },
+    {
+      name     = "public"
+      new_bits = 2
+    },
+  ]
+}
+
+# Divide the private groups by AZ and provide each with a /22 CIDR
+module "private_subnet_cidrs" {
+  source = "hashicorp/subnets/cidr"
+
+  base_cidr_block = module.subnet_group_cidrs.base_cidr_block
+  networks = [for az_name in sort(data.aws_availability_zones.this.names) : {name = az_name, new_bits = 4}]
+}
+
+# Divide the public groups by AZ and provide each with a /22 CIDR
+module "public_subnet_cidrs" {
+  source = "hashicorp/subnets/cidr"
+
+  base_cidr_block = module.subnet_group_cidrs.base_cidr_block
+  networks = [for az_name in sort(data.aws_availability_zones.this.names) : {name = az_name, new_bits = 4}]
+}
+
+locals {
+  subnet_count = length(data.aws_availability_zones.this.names)
+}
+
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name = "base"
+  cidr = var.cidr_block
+
+  enable_ipv6                     = true
+  assign_ipv6_address_on_creation = true
+
+
+  azs             = sort(data.aws_availability_zones.this.names)
+  private_subnets = values(module.private_subnet_cidrs.network_cidr_blocks)
+  public_subnets  = values(module.public_subnet_cidrs.network_cidr_blocks)
+
+  private_subnet_ipv6_prefixes = range(local.subnet_count)
+  public_subnet_ipv6_prefixes	= range(local.subnet_count, local.subnet_count * 2)
+
+  enable_nat_gateway = true
+
+  tags = merge(var.tags)
+}

--- a/infrastructure/000-aws-base/terraform.tf
+++ b/infrastructure/000-aws-base/terraform.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.7.0"
+    }
+  }
+}

--- a/infrastructure/000-aws-base/vpc.tf
+++ b/infrastructure/000-aws-base/vpc.tf
@@ -25,66 +25,42 @@ module "vpc_cidrs" {
   ]
 }
 
-// Get a list of AZs supported by this region so we can put a subnet in each one
-data "aws_availability_zones" "us_east_1" {
-  provider = aws.us_east_1
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
+# module "aws_vpc_us_east_1" {
+#   source = "./modules/vpc"
+#   providers = {
+#     aws = aws.us_east_1
+#   }
 
-// Divide the subnets into groups and provide each group with a /18 space CIDR
-module "us_east_1_subnet_group_cidrs" {
-  source = "hashicorp/subnets/cidr"
+#   cidr_block = module.vpc_cidrs.network_cidr_blocks.us_east_1
+#   tags       = merge(local.common_tags)
+# }
 
-  base_cidr_block = module.vpc_cidrs.network_cidr_blocks.us_east_1
-  networks = [
-    {
-      name     = "private"
-      new_bits = 2
-    },
-    {
-      name     = "public"
-      new_bits = 2
-    },
-  ]
-}
-
-// Divide the private groups by AZ and provide each with a /22 CIDR
-module "us_east_1_private_subnet_cidrs" {
-  source = "hashicorp/subnets/cidr"
-
-  base_cidr_block = module.us_east_1_subnet_group_cidrs.base_cidr_block
-  networks = [for az_name in sort(data.aws_availability_zones.us_east_1.names) : {name = az_name, new_bits = 4}]
-}
-
-// Divide the public groups by AZ and provide each with a /22 CIDR
-module "us_east_1_public_subnet_cidrs" {
-  source = "hashicorp/subnets/cidr"
-
-  base_cidr_block = module.us_east_1_subnet_group_cidrs.base_cidr_block
-  networks = [for az_name in sort(data.aws_availability_zones.us_east_1.names) : {name = az_name, new_bits = 4}]
-}
-
-module "vpc_us_east_1" {
-  source = "terraform-aws-modules/vpc/aws"
+module "aws_vpc_us_east_2" {
+  source = "./modules/vpc"
   providers = {
-    aws = aws.us_east_1
+    aws = aws.us_east_2
   }
 
-  name = "base"
-  cidr = module.vpc_cidrs.network_cidr_blocks.us_east_1
+  cidr_block = module.vpc_cidrs.network_cidr_blocks.us_east_2
+  tags       = merge(local.common_tags)
+}
 
-  enable_ipv6                     = true
-  assign_ipv6_address_on_creation = true
+module "aws_vpc_us_west_1" {
+  source = "./modules/vpc"
+  providers = {
+    aws = aws.us_west_1
+  }
 
+  cidr_block = module.vpc_cidrs.network_cidr_blocks.us_west_1
+  tags       = merge(local.common_tags)
+}
 
-  azs             = sort(data.aws_availability_zones.us_east_1.names)
-  private_subnets = values(module.us_east_1_private_subnet_cidrs.network_cidr_blocks)
-  public_subnets  = values(module.us_east_1_public_subnet_cidrs.network_cidr_blocks)
+module "aws_vpc_us_west_2" {
+  source = "./modules/vpc"
+  providers = {
+    aws = aws.us_west_2
+  }
 
-  enable_nat_gateway = true
-
-  tags = merge(local.common_tags)
+  cidr_block = module.vpc_cidrs.network_cidr_blocks.us_west_2
+  tags       = merge(local.common_tags)
 }


### PR DESCRIPTION
- Move vpc call to a module so we can repeatedly for each region
- Call repeatedly for each region
- Remove east-1 to make sure we can re-enable it