### PR TITLE
feat: enable us-east-1 zone for vpc

### DIFF
--- a/infrastructure/000-aws-base/vpc.tf
+++ b/infrastructure/000-aws-base/vpc.tf
@@ -25,15 +25,15 @@ module "vpc_cidrs" {
   ]
 }
 
-# module "aws_vpc_us_east_1" {
-#   source = "./modules/vpc"
-#   providers = {
-#     aws = aws.us_east_1
-#   }
+module "aws_vpc_us_east_1" {
+  source = "./modules/vpc"
+  providers = {
+    aws = aws.us_east_1
+  }
 
-#   cidr_block = module.vpc_cidrs.network_cidr_blocks.us_east_1
-#   tags       = merge(local.common_tags)
-# }
+  cidr_block = module.vpc_cidrs.network_cidr_blocks.us_east_1
+  tags       = merge(local.common_tags)
+}
 
 module "aws_vpc_us_east_2" {
   source = "./modules/vpc"


### PR DESCRIPTION
## Purpose

Enable US East 1 (Virginia) Region VPC.
Previously, this had been commented out to allow the old module to correctly delete before a new module could take its place.