### PR TITLE
Add DynamoDB Endpoint to VPCs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# DavidJFelix has terraform cloud access and should be included on any PR for infrastructure code
+/infrastructure/ @davidjfelix

--- a/infrastructure/000-aws-base/README.md
+++ b/infrastructure/000-aws-base/README.md
@@ -1,0 +1,36 @@
+# 000-aws-base
+
+AWS base is a `terraform` package that creates a baseline AWS account for this project. It sets up centralized logging and access resources as well as a baseline VPC and network.
+
+## Resources
+
+* VPC per region
+  - Private subnet per AZ
+  - Public subnet per AZ
+  - Security groups
+  - Route tables
+  - Internet Gateway
+  - NAT Gateway
+* VPC endpoint per region for dynamodb
+* S3 Logging bucket, for logging access **to** s3 in one location.
+* KMS customer master key & alias
+* IAM automation users
+
+## Outputs
+
+* S3 Logging bucket name, so additional buckets can use this to log access
+* VPC ids for each regional VPC
+  - Private subnet ids for each region
+  - Public subnet ids for each region
+  - Security group ids for each region
+* IAM automation user credentials
+  - these are encrypted using keybase pgp
+* KMS customer master key alias
+
+## Disaster Recovery
+
+This package is marked `000` and has no dependencies.
+It should be run first or with other `000` packages.
+
+* Create an admin AWS user with CLI access and a key pair
+* Run this package providing those credentials to the `aws provider` in `terraform`

--- a/infrastructure/000-aws-base/iam.tf
+++ b/infrastructure/000-aws-base/iam.tf
@@ -1,0 +1,25 @@
+resource "aws_iam_access_key" "terraform_cloud" {
+  user = aws_iam_user.terraform_cloud.name
+  pgp_key = "keybase:davidjfelix"
+}
+
+resource "aws_iam_access_key" "github_serverless" {
+  user = aws_iam_user.github_serverless.name
+  pgp_key = "keybase:davidjfelix"
+}
+
+
+resource "aws_iam_group" "automation_cicd" {
+  name = "automation-cicd"
+  path = "/automation/cicd/"
+}
+
+resource "aws_iam_user" "terraform_cloud" {
+  name = "terraform-cloud"
+  path = "/automation/cicd/terraform-cloud"
+}
+
+resource "aws_iam_user" "github_serverless" {
+  name = "github-serverless"
+  path = "/automation/cicd/github-serverless"
+}

--- a/infrastructure/000-aws-base/modules/vpc/outputs.tf
+++ b/infrastructure/000-aws-base/modules/vpc/outputs.tf
@@ -1,3 +1,15 @@
 output "vpc_id" {
   value = module.vpc.vpc_id
 }
+
+output "private_subnets" {
+  value = module.vpc.private_subnets
+}
+
+output "public_subnets" {
+  value = module.vpc.public_subnets
+}
+
+output "intra_subnets" {
+  value = module.vpc.intra_subnets
+}

--- a/infrastructure/000-aws-base/outputs.tf
+++ b/infrastructure/000-aws-base/outputs.tf
@@ -9,3 +9,83 @@ output "kms_key_id" {
 output "s3_access_logs_s3_bucket_id" {
   value = aws_s3_bucket.s3_access_logs.id
 }
+
+output "aws_vpc_us_east_1_vpc_id" {
+  value = module.aws_vpc_us_east_1.vpc_id
+}
+
+output "aws_vpc_us_east_2_vpc_id" {
+  value = module.aws_vpc_us_east_2.vpc_id
+}
+
+output "aws_vpc_us_west_1_vpc_id" {
+  value = module.aws_vpc_us_west_1.vpc_id
+}
+
+output "aws_vpc_us_west_2_vpc_id" {
+  value = module.aws_vpc_us_west_2.vpc_id
+}
+
+output "aws_vpc_us_east_1_private_subnets" {
+  value = module.aws_vpc_us_east_1.private_subnets
+}
+
+output "aws_vpc_us_east_2_private_subnets" {
+  value = module.aws_vpc_us_east_2.private_subnets
+}
+
+output "aws_vpc_us_west_1_private_subnets" {
+  value = module.aws_vpc_us_west_1.private_subnets
+}
+
+output "aws_vpc_us_west_2_private_subnets" {
+  value = module.aws_vpc_us_west_2.private_subnets
+}
+
+output "aws_vpc_us_east_1_public_subnets" {
+  value = module.aws_vpc_us_east_1.public_subnets
+}
+
+output "aws_vpc_us_east_2_public_subnets" {
+  value = module.aws_vpc_us_east_2.public_subnets
+}
+
+output "aws_vpc_us_west_1_public_subnets" {
+  value = module.aws_vpc_us_west_1.public_subnets
+}
+
+output "aws_vpc_us_west_2_public_subnets" {
+  value = module.aws_vpc_us_west_2.public_subnets
+}
+
+output "aws_vpc_us_east_1_intra_subnets" {
+  value = module.aws_vpc_us_east_1.intra_subnets
+}
+
+output "aws_vpc_us_east_2_intra_subnets" {
+  value = module.aws_vpc_us_east_2.intra_subnets
+}
+
+output "aws_vpc_us_west_1_intra_subnets" {
+  value = module.aws_vpc_us_west_1.intra_subnets
+}
+
+output "aws_vpc_us_west_2_intra_subnets" {
+  value = module.aws_vpc_us_west_2.intra_subnets
+}
+
+output "terraform_cloud_iam_access_key_id" {
+  value = aws_iam_access_key.terraform_cloud.id
+}
+
+output "terraform_cloud_encrypted_iam_secret_access_key" {
+  value = aws_iam_access_key.terraform_cloud.encrypted_secret
+}
+
+output "github_serverless_iam_access_key_id" {
+  value = aws_iam_access_key.github_serverless.id
+}
+
+output "github_serverless_encrypted_iam_secret_access_key" {
+  value = aws_iam_access_key.github_serverless.encrypted_secret
+}

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,25 @@
+# Infrastructure
+
+This folder contains a number of packages used to create the infrastructure for this project.
+Each package is self contained, but the packages are organized in a way that represents some of the inter-package dependencies.
+The primary technology for managing infrastructure is `terraform` with state managed remotely in [Terraform Cloud](https://app.terraform.io/).
+Most infrastructure is managed in this directory, but some ad-hoc and project level infrastructure is managed by outside tools which may or many not reference values managed in this folder.
+One notable external tool is `serverless` which manages `CloudFormation` apps and AWS lambdas itself.
+The `serverless` code does reference values declared in this folder.
+
+## Organization
+
+Projects are designed to govern independent resource goals, but may have inter-stack dependencies that dictate the order in which they run and required packages.
+The order to run these packages is instructed by a 3-digit prefix number (eg: `000-name`). These numbers can be duplicated and are ordered lowest-first. The most significant 2 digits are designed to be used for normal use cases while the least significant digit should **normally** be "0". The least significant digit is for squeezing new packages between dependent items and should be used with caution.
+
+## Disaster Recovery
+
+* Create an Admin AWS user with CLI access.
+* Run each package/subdirectory in this folder in numeric order, following the README instructions in each package.
+Projects with the same number prefix are considered peers and not dependent on each other, so they may be run concurrently. For example:
+  - Run `000-aws-base` first
+  - Run `010-aws-api` and `010-example-project` concurrently or in any order second.
+  - Run `020-second-example` after all previous projects have completed
+
+These plans don't include notes for setting up terraform cloud or AWS accounts.
+In the event of a disaster, those questions should be asked external to this project, as these instructions only help with direct infrastructure recovery, not CI/CD recovery.


### PR DESCRIPTION
# Purpose

This change primarily adds a [VPC endpoint](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints.html) for DynamoDB within the base `VPC`.
This allows private and intra (private without `NAT Gateway`) `subnet`s to access an AWS Service (in this case, `DynamoDB`) using an internal route, rather than going out the internet gateway. As a consequence of this allowance, we are further allowed to setup a stricter `IAM Access Policy` on `DynamoDB` which prevents all access from systems outside of our VPC.

## Details of the change

* Add VPC endpoint for dynamodb to vpc module
* Add intra subnets (we'll probably use these for `lambda`)

## Additional Unrelated changes of this PR

* Add `CODEOWNERS` file and start tracking myself for `/infrastructure/`
* Add `README.md` files to each directory to provide better direction and guidance for operating