### PR TITLE
chore: enable monorepo build

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["src"]
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "@babel/preset-typescript": "^7.14.5",
     "@cloudflare/wrangler": "^1.17.0",
     "@manypkg/cli": "^0.18.0",
-    "@preconstruct/cli": "^2.1.0"
+    "@preconstruct/cli": "^2.1.0",
+    "@tsconfig/recommended": "^1.0.1"
   },
   "preconstruct": {
     "packages": [

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "types"
   ],
   "scripts": {
+    "build": "preconstruct build && manypkg run dashboard build",
     "postinstall": "preconstruct dev",
     "start": "manypkg run dashboard dev"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@tsconfig/recommended/tsconfig.json"
+}

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2117,6 +2117,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@tsconfig/recommended@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/recommended/-/recommended-1.0.1.tgz#7619bad397e06ead1c5182926c944e0ca6177f52"
+  integrity sha512-2xN+iGTbPBEzGSnVp/Hd64vKJCJWxsi9gfs88x4PPMyEjHJoA3o5BY9r5OLPHIZU2pAQxkSAsJFqn6itClP8mQ==
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.14"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.14.tgz#faaeefc4185ec71c389f4501ee5ec84b170cc402"


### PR DESCRIPTION
This PR resolves the build errors on Vercel by
- adding a `build` script
	- runs `preconstruct build` which builds and makes available the `@toglion/types` package
	- runs `manypkg run dashboard build` which builds the `dashboard` site
- adding more `tsconfig.json` files
	- added root `tsconfig.json` which extends from `@tsconfig/recommended/tsconfig.json`
	- added `tsconfig.json` files for `client` and `types` which extend from the root

On the Vercel side, I also had to make a few changes:
- changed root directory to `./` so we can utilize the `build` script for all packages
- updated build command to `yarn build`
- updated output directory to `./dashboard/.next`