### PR TITLE
Create API Terraform resources

### DIFF
--- a/infrastructure/000-aws-base/modules/vpc/README.md
+++ b/infrastructure/000-aws-base/modules/vpc/README.md
@@ -1,0 +1,4 @@
+# VPC module
+
+This module wraps the `terraform-aws-modules/vpc/aws` module with settings so that it can be quickly duplicated per region.
+It creates a VPC endpoint for DynamoDB and a uniform set of subnets and CIDR pattern for them.

--- a/infrastructure/000-aws-base/modules/vpc/outputs.tf
+++ b/infrastructure/000-aws-base/modules/vpc/outputs.tf
@@ -13,3 +13,7 @@ output "public_subnets" {
 output "intra_subnets" {
   value = module.vpc.intra_subnets
 }
+
+output "default_security_group_id" {
+  value = module.vpc.default_security_group_id
+}

--- a/infrastructure/000-aws-base/modules/vpc/terraform.tf
+++ b/infrastructure/000-aws-base/modules/vpc/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.7.0"
+      version = ">= 3.15.0"
     }
   }
 }

--- a/infrastructure/000-aws-base/outputs.tf
+++ b/infrastructure/000-aws-base/outputs.tf
@@ -74,6 +74,22 @@ output "aws_vpc_us_west_2_intra_subnets" {
   value = module.aws_vpc_us_west_2.intra_subnets
 }
 
+output "aws_vpc_us_east_1_default_security_group_id" {
+  value = module.aws_vpc_us_east_1.default_security_group_id
+}
+
+output "aws_vpc_us_east_2_default_security_group_id" {
+  value = module.aws_vpc_us_east_2.default_security_group_id
+}
+
+output "aws_vpc_us_west_1_default_security_group_id" {
+  value = module.aws_vpc_us_west_1.default_security_group_id
+}
+
+output "aws_vpc_us_west_2_default_security_group_id" {
+  value = module.aws_vpc_us_west_2.default_security_group_id
+}
+
 output "terraform_cloud_iam_access_key_id" {
   value = aws_iam_access_key.terraform_cloud.id
 }

--- a/infrastructure/000-aws-base/terraform.tf
+++ b/infrastructure/000-aws-base/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.7.0"
+      version = ">= 3.15.0"
     }
   }
 }

--- a/infrastructure/010-aws-api/README.md
+++ b/infrastructure/010-aws-api/README.md
@@ -1,0 +1,3 @@
+# 010-aws-api
+
+AWS API is a `terraform` package that creates AWS resources for the API and serverless codebase to deploy to.

--- a/infrastructure/010-aws-api/aws.tf
+++ b/infrastructure/010-aws-api/aws.tf
@@ -1,0 +1,28 @@
+// Default AWS provider is in the region us-east-1 (Viginia)
+provider "aws" {
+  region = "us-east-1"
+}
+
+// Define aliases for other AWS regions
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "us_east_2"
+  region = "us-east-2"
+}
+
+provider "aws" {
+  alias  = "us_west_1"
+  region = "us-west-1"
+}
+
+provider "aws" {
+  alias  = "us_west_2"
+  region = "us-west-2"
+}
+
+// Create a pointer to the caller identity which provides reflective account information
+data "aws_caller_identity" "current" {}

--- a/infrastructure/010-aws-api/dynamodb.tf
+++ b/infrastructure/010-aws-api/dynamodb.tf
@@ -1,0 +1,72 @@
+# Global primary database for app data
+module "global_dynamodb_table" {
+  source = "./modules/dynamodb"
+  providers = {
+    aws = aws.us_east_1
+  }
+
+  name_prefix                        = "api-global"
+  is_global                          = true
+  server_side_encryption_kms_key_arn = aws_kms_key.dynamodb_us_east_1.arn
+
+  replica_regions = [
+    {
+      region_name = "us-east-2"
+      kms_key_arn = aws_kms_key.dynamodb_us_east_2.arn
+    },
+    {
+      region_name = "us-west-1"
+      kms_key_arn = aws_kms_key.dynamodb_us_west_1.arn
+    },
+    {
+      region_name = "us-west-2"
+      kms_key_arn = aws_kms_key.dynamodb_us_west_2.arn
+    }
+  ]
+
+  tags = merge(local.common_tags)
+}
+
+# Regioanl Databases for app session data
+module "us_east_1_dynamodb_table" {
+  source = "./modules/dynamodb"
+  providers = {
+    aws = aws.us_east_1
+  }
+
+  name_prefix                        = "api-regional"
+  server_side_encryption_kms_key_arn = aws_kms_key.dynamodb_us_east_2.arn
+  tags                               = merge(local.common_tags)
+}
+
+module "us_east_2_dynamodb_table" {
+  source = "./modules/dynamodb"
+  providers = {
+    aws = aws.us_east_1
+  }
+
+  name_prefix = "api-regional"
+  tags        = merge(local.common_tags)
+}
+
+module "us_west_1_dynamodb_table" {
+  source = "./modules/dynamodb"
+  providers = {
+    aws = aws.us_east_1
+  }
+
+  name_prefix                        = "api-regional"
+  server_side_encryption_kms_key_arn = aws_kms_key.dynamodb_us_west_1.arn
+  tags                               = merge(local.common_tags)
+}
+
+module "us_west_2_dynamodb_table" {
+  source = "./modules/dynamodb"
+  providers = {
+    aws = aws.us_east_1
+  }
+
+  name_prefix                        = "api-regional"
+  server_side_encryption_kms_key_arn = aws_kms_key.dynamodb_us_west_2.arn
+  tags                               = merge(local.common_tags)
+}

--- a/infrastructure/010-aws-api/iam.tf
+++ b/infrastructure/010-aws-api/iam.tf
@@ -1,0 +1,84 @@
+data "aws_iam_policy" "lambda_vpc_managed_policy" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+// The assume role policy for the application execution role
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+// The permission boundary to be used by the execution role
+data "aws_iam_policy_document" "lambda_execution_permission_boundary" {
+  statement {
+    effect = "Allow"
+    sid    = "ServiceBoundaries"
+
+    actions = [
+      "execute-api:*",
+      "ec2:*",
+      "dynamodb:*",
+      "kms:*",
+      "lambda:*",
+      "s3:*",
+    ]
+
+    resources = [
+      "*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "lambda_execution_permission_boundary" {
+  description = "The policy boundary for the Lambda API role"
+  name_prefix = "APILambda"
+  path        = "/boundaries/services/api/"
+  policy      = data.aws_iam_policy_document.lambda_execution_permission_boundary.json
+}
+
+resource "aws_iam_role" "lambda_role" {
+  assume_role_policy   = data.aws_iam_policy_document.lambda_assume_role.json
+  description          = "The role used by Lambda for API during execution"
+  name_prefix          = "APILambda"
+  path                 = "/services/api/"
+  permissions_boundary = aws_iam_policy.lambda_execution_permission_boundary.arn
+
+  tags = merge(local.common_tags)
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_vpc_managed_policy" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = data.lambda_vpc_managed_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "global_dynamodb" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = module.global_dynamodb_table.iam_policy_dynamodb_read_write_arn
+}
+
+resource "aws_iam_role_policy_attachment" "us_east_1_dynamodb" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = module.us_east_1_dynamodb_table.iam_policy_dynamodb_read_write_arn
+}
+
+resource "aws_iam_role_policy_attachment" "us_east_2_dynamodb" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = module.us_east_2_dynamodb_table.iam_policy_dynamodb_read_write_arn
+}
+
+resource "aws_iam_role_policy_attachment" "us_west_1_dynamodb" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = module.us_west_1_dynamodb_table.iam_policy_dynamodb_read_write_arn
+}
+
+resource "aws_iam_role_policy_attachment" "us_east_2_dynamodb" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = module.us_west_2_dynamodb_table.iam_policy_dynamodb_read_write_arn
+}

--- a/infrastructure/010-aws-api/kms.tf
+++ b/infrastructure/010-aws-api/kms.tf
@@ -1,0 +1,51 @@
+resource "aws_kms_key" "dynamodb_us_east_1" {
+  provider            = aws.us_east_1
+  description         = "A key for the dynamodb tables for the API application"
+  enable_key_rotation = true
+  tags                = merge(local.common_tags)
+}
+
+resource "aws_kms_alias" "dynamodb_us_east_1" {
+  provider      = aws.us_east_1
+  name_prefix   = "alias/api/dynamodb"
+  target_key_id = aws_kms_key.dynamodb_us_east_1.key_id
+}
+
+resource "aws_kms_key" "dynamodb_us_east_2" {
+  provider            = aws.us_east_2
+  description         = "A key for the dynamodb tables for the API application"
+  enable_key_rotation = true
+  tags                = merge(local.common_tags)
+}
+
+resource "aws_kms_alias" "dynamodb_us_east_2" {
+  provider      = aws.us_east_2
+  name_prefix   = "alias/api/dynamodb"
+  target_key_id = aws_kms_key.dynamodb_us_east_2.key_id
+}
+
+resource "aws_kms_key" "dynamodb_us_west_1" {
+  provider            = aws.us_west_1
+  description         = "A key for the dynamodb tables for the API application"
+  enable_key_rotation = true
+  tags                = merge(local.common_tags)
+}
+
+resource "aws_kms_alias" "dynamodb_us_west_1" {
+  provider      = aws.us_west_1
+  name_prefix   = "alias/api/dynamodb"
+  target_key_id = aws_kms_key.dynamodb_us_west_1.key_id
+}
+
+resource "aws_kms_key" "dynamodb_us_west_2" {
+  provider            = aws.us_west_2
+  description         = "A key for the dynamodb tables for the API application"
+  enable_key_rotation = true
+  tags                = merge(local.common_tags)
+}
+
+resource "aws_kms_alias" "dynamodb_us_west_2" {
+  provider      = aws.us_west_2
+  name_prefix   = "alias/api/dynamodb"
+  target_key_id = aws_kms_key.dynamodb_us_west_2.key_id
+}

--- a/infrastructure/010-aws-api/locals.tf
+++ b/infrastructure/010-aws-api/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  common_tags = {
+    Application = "Toglion API"
+    Stack       = "010-aws-api"
+    IsTerraform = "true"
+  }
+}

--- a/infrastructure/010-aws-api/modules/dynamodb/README.md
+++ b/infrastructure/010-aws-api/modules/dynamodb/README.md
@@ -1,0 +1,4 @@
+# DynamoDB module
+
+This module wraps the `terraform-aws-modules/dynamodb-table/aws` module with some preferred settings.
+It sets up the primary key, encryption settings, indexes and replication settings in a uniform way.

--- a/infrastructure/010-aws-api/modules/dynamodb/dynamodb.tf
+++ b/infrastructure/010-aws-api/modules/dynamodb/dynamodb.tf
@@ -1,0 +1,53 @@
+module "this" {
+  source = "terraform-aws-modules/dynamodb-table/aws"
+
+  name      = "${var.name_prefix}-${random_id.this.hex}"
+  hash_key  = "PartitionKey"
+  range_key = "SortKey"
+
+  # Enable streaming to allow for global replication
+  stream_enabled   = var.is_global
+  stream_view_type = var.is_global ? "NEW_AND_OLD_IMAGES" : null
+
+  server_side_encryption_enabled     = true
+  server_side_encryption_kms_key_arn = var.server_side_encryption_kms_key_arn
+
+  attributes = [
+    {
+      name = "PartitionKey"
+      type = "S"
+    },
+    {
+      name = "SortKey"
+      type = "S"
+    },
+    {
+      name = "Value"
+      type = "S"
+    }
+  ]
+
+  global_secondary_indexes = [
+    {
+      hash_key        = "SortKey"
+      name            = "InverseIndex"
+      projection_type = "KEYS_ONLY"
+      range_key       = "PartitionKey"
+    },
+    {
+      hash_key        = "Value"
+      name            = "ValueIndex"
+      projection_type = "ALL"
+      range_key       = "PartitionKey"
+    }
+  ]
+
+  point_in_time_recovery_enabled = true
+
+  replica_regions = var.replica_regions
+
+  ttl_attribute_name = "TTL"
+  ttl_enabled        = true
+
+  tags = merge(var.tags)
+}

--- a/infrastructure/010-aws-api/modules/dynamodb/iam.tf
+++ b/infrastructure/010-aws-api/modules/dynamodb/iam.tf
@@ -1,0 +1,30 @@
+data "aws_iam_policy_document" "read_write" {
+  statement {
+    effect = "Allow"
+    sid    = "AllowClientDynamoDB"
+
+    actions = [
+      "dynamodb:BatchGetItem",
+      "dynamodb:BatchWriteItem",
+      "dynamodb:ConditionCheckItem",
+      "dynamodb:DeleteItem",
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "dynamodb:UpdateItem",
+    ]
+
+    resources = [
+      "${module.this.dynamo_db_table_arn}",
+      "${module.this.dynamo_db_table_arn}/index/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "read_write" {
+  description = "Permits read, write, query and scan items on the ${module.this.dynamo_db_table_id} table and its indexes"
+  name_prefix = "ClientPolicy"
+  path        = "/databases/dynamodb/${var.name_prefix}-${var.is_global ? "global" : "regional"}/${random_id.this.hex}/"
+  policy      = data.aws_iam_policy_document.read_write.json
+}

--- a/infrastructure/010-aws-api/modules/dynamodb/outputs.tf
+++ b/infrastructure/010-aws-api/modules/dynamodb/outputs.tf
@@ -1,0 +1,25 @@
+
+output "dynamodb_table_arn" {
+  description = "ARN of the DynamoDB table"
+  value       = module.dynamodb_table_arn
+}
+
+output "dynamodb_table_id" {
+  description = "ID of the DynamoDB table"
+  value       = module.dynamodb_table_id
+}
+
+output "dynamodb_table_stream_arn" {
+  description = "The ARN of the Table Stream. Only available when var.is_global is true"
+  value       = var.is_global ? module.this.dynamodb_table_stream_arn : null
+}
+
+output "dynamodb_table_stream_label" {
+  description = "A timestamp, in ISO 8601 format of the Table Stream. Only available when var.is_global is true"
+  value       = var.is_global ? module.this.dynamodb_table_stream_label : null
+}
+
+output "iam_policy_dynamodb_read_write_arn" {
+  description = "The ARN for a policy which allows read/write to the dynamodb table created by this module"
+  value       = aws_iam_policy.read_write.arn
+}

--- a/infrastructure/010-aws-api/modules/dynamodb/random.tf
+++ b/infrastructure/010-aws-api/modules/dynamodb/random.tf
@@ -1,0 +1,3 @@
+resource "random_id" "this" {
+  byte_length = 8
+}

--- a/infrastructure/010-aws-api/modules/dynamodb/terraform.tf
+++ b/infrastructure/010-aws-api/modules/dynamodb/terraform.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.37.0"
+    }
+  }
+}

--- a/infrastructure/010-aws-api/modules/dynamodb/variables.tf
+++ b/infrastructure/010-aws-api/modules/dynamodb/variables.tf
@@ -1,0 +1,26 @@
+variable "is_global" {
+  description = "Whether or not its a global table"
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "Name of the DynamoDB table"
+  type        = string
+}
+
+variable "replica_regions" {
+  description = "Region names for creating replicas for a global DynamoDB table"
+  type        = list(map(any))
+  default     = []
+}
+
+variable "server_side_encryption_kms_key_arn" {
+  description = "The ARN of the CMK that should be used for the AWS KMS encryption"
+  type        = string
+}
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infrastructure/010-aws-api/modules/serverless-ssm/README.md
+++ b/infrastructure/010-aws-api/modules/serverless-ssm/README.md
@@ -1,0 +1,4 @@
+# Serverless SSM module
+
+This module provides a number of SSM parameters for a serverless deployment.
+These parameters are passed into serverless during deployment to a given region

--- a/infrastructure/010-aws-api/modules/serverless-ssm/ssm.tf
+++ b/infrastructure/010-aws-api/modules/serverless-ssm/ssm.tf
@@ -1,0 +1,47 @@
+resource "aws_ssm_parameter" "serverless_deployment_bucket" {
+  name  = "/services/api/SERVERLESS_DEPLOYMENT_BUCKET"
+  type  = "String"
+  value = var.serverless_deployment_bucket
+
+  tags = merge(local.common_tags)
+}
+
+resource "aws_ssm_parameter" "lambda_role_arn" {
+  name  = "/services/api/LAMBDA_ROLE_ARN"
+  type  = "String"
+  value = var.lambda_role_arn
+
+  tags = merge(local.common_tags)
+}
+
+resource "aws_ssm_parameter" "lambda_subnets" {
+  name  = "/services/api/LAMBDA_SUBNETS"
+  type  = "StringList"
+  value = join(",", var.subnets)
+
+  tags = merge(var.tags)
+}
+
+resource "aws_ssm_parameter" "lambda_security_group" {
+  name  = "/services/api/LAMBDA_SECURITY_GROUPS"
+  type  = "StringList"
+  value = join(",", var.security_groups)
+
+  tags = merge(var.tags)
+}
+
+resource "aws_ssm_parameter" "global_dynamodb_table" {
+  name  = "/services/api/GLOBAL_DYNAMODB_TABLE"
+  type  = "String"
+  value = var.global_dynamodb_table
+
+  tags = merge(var.tags)
+}
+
+resource "aws_ssm_parameter" "regional_dynamodb_table" {
+  name  = "/services/api/REGIONAL_DYNAMODB_TABLE"
+  type  = "String"
+  value = var.regional_dynamodb_table
+
+  tags = merge(var.tags)
+}

--- a/infrastructure/010-aws-api/modules/serverless-ssm/terraform.tf
+++ b/infrastructure/010-aws-api/modules/serverless-ssm/terraform.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.37.0"
+    }
+  }
+}

--- a/infrastructure/010-aws-api/modules/serverless-ssm/variables.tf
+++ b/infrastructure/010-aws-api/modules/serverless-ssm/variables.tf
@@ -1,0 +1,31 @@
+variable "subnets" {
+  description = "The subnets to deploy the lambda to"
+  type        = list(string)
+  default     = []
+}
+
+variable "security_groups" {
+  description = "The security groups to deploy the lambda to"
+  type        = list(string)
+  default     = []
+}
+
+variable "role_arn" {
+  description = "The ARN of the lambda execution role"
+  type        = string
+}
+
+variable "deployment_bucket" {
+  description = "The bucket to deploy serverless code to"
+  type        = string
+}
+
+variable "global_dynamodb_table" {
+  description = "The global table used as an application database"
+  type        = string
+}
+
+variable "regional_dynamodb_table" {
+  description = "The regional table used as a region-local database"
+  type        = string
+}

--- a/infrastructure/010-aws-api/s3.tf
+++ b/infrastructure/010-aws-api/s3.tf
@@ -1,0 +1,19 @@
+resource "aws_s3_bucket" "serverless_code" {
+  acl           = "private"
+  bucket_prefix = "serverless-code"
+  tags          = merge(local.common_tags)
+
+  logging {
+    target_bucket = data.terraform_remote_state.aws_base.outputs.s3_access_logs_s3_bucket_id
+    target_prefix = "aws/s3/${locals.common_tags.Stack}/serverless-code/"
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm     = "aws:kms"
+        kms_master_key_id = data.terraform_remote_state.aws_base.outputs.terraform_cloud_iam_access_key_id
+      }
+    }
+  }
+}

--- a/infrastructure/010-aws-api/ssm.tf
+++ b/infrastructure/010-aws-api/ssm.tf
@@ -1,0 +1,47 @@
+module "us_east_1_serverless_ssm" {
+  source = "./modules/serverless-ssm"
+  providers = {
+    aws = aws.us_east_1
+  }
+
+  role_arn          = aws_iam_role.lambda_role.arn
+  subnets           = data.terraform_remote_state.aws_base.outputs.aws_vpc_us_east_1_intra_subnets
+  security_groups   = [data.terraform_remote_state.aws_base.outputs.aws_vpc_us_east_1_default_security_group_id]
+  deployment_bucket = aws_s3_bucket.serverless_code.id
+}
+
+module "us_east_2_serverless_ssm" {
+  source = "./modules/serverless-ssm"
+  providers = {
+    aws = aws.us_east_2
+  }
+
+  role_arn          = aws_iam_role.lambda_role.arn
+  subnets           = data.terraform_remote_state.aws_base.outputs.aws_vpc_us_east_2_intra_subnets
+  security_groups   = [data.terraform_remote_state.aws_base.outputs.aws_vpc_us_east_2_default_security_group_id]
+  deployment_bucket = aws_s3_bucket.serverless_code.id
+}
+
+module "us_west_1_serverless_ssm" {
+  source = "./modules/serverless-ssm"
+  providers = {
+    aws = aws.us_west_1
+  }
+
+  role_arn          = aws_iam_role.lambda_role.arn
+  subnets           = data.terraform_remote_state.aws_base.outputs.aws_vpc_us_west_1_intra_subnets
+  security_groups   = [data.terraform_remote_state.aws_base.outputs.aws_vpc_us_west_1_default_security_group_id]
+  deployment_bucket = aws_s3_bucket.serverless_code.id
+}
+
+module "us_west_2_serverless_ssm" {
+  source = "./modules/serverless-ssm"
+  providers = {
+    aws = aws.us_west_2
+  }
+
+  role_arn          = aws_iam_role.lambda_role.arn
+  subnets           = data.terraform_remote_state.aws_base.outputs.aws_vpc_us_west_2_intra_subnets
+  security_groups   = [data.terraform_remote_state.aws_base.outputs.aws_vpc_us_west_2_default_security_group_id]
+  deployment_bucket = aws_s3_bucket.serverless_code.id
+}

--- a/infrastructure/010-aws-api/terraform.tf
+++ b/infrastructure/010-aws-api/terraform.tf
@@ -1,0 +1,19 @@
+data "terraform_remote_state" "aws_base" {
+  backend = "remote"
+
+  config = {
+    organization = "toglion"
+    workspaces = {
+      name = "000-aws-base"
+    }
+  }
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.37.0"
+    }
+  }
+}


### PR DESCRIPTION
# Purpose

Create an initial terraform stack for API resources.
This PR adds both the `010-aws-api` stack and some outputs from `000-aws-base` to link the two together.

### Created resources

* DynamoDB global table for application code
* DynamoDB local tables for websocket connections
* IAM role for lambda execution
* S3 bucket for serverless deployment
* SSM parameters for serverless to use on lambda deployment

### Additional Fixes

READMEs are being added to clarify some of the purpose of modules.