### PR TITLE
fix: typo with aws provider for local dynamodb modules

### DIFF
--- a/infrastructure/010-aws-api/dynamodb.tf
+++ b/infrastructure/010-aws-api/dynamodb.tf
@@ -42,7 +42,7 @@ module "us_east_1_dynamodb_table" {
 module "us_east_2_dynamodb_table" {
   source = "./modules/dynamodb"
   providers = {
-    aws = aws.us_east_1
+    aws = aws.us_east_2
   }
 
   name_prefix                        = "api-regional"
@@ -53,7 +53,7 @@ module "us_east_2_dynamodb_table" {
 module "us_west_1_dynamodb_table" {
   source = "./modules/dynamodb"
   providers = {
-    aws = aws.us_east_1
+    aws = aws.us_west_1
   }
 
   name_prefix                        = "api-regional"
@@ -64,7 +64,7 @@ module "us_west_1_dynamodb_table" {
 module "us_west_2_dynamodb_table" {
   source = "./modules/dynamodb"
   providers = {
-    aws = aws.us_east_1
+    aws = aws.us_west_2
   }
 
   name_prefix                        = "api-regional"


### PR DESCRIPTION
# Description

DynamoDB modules couldn't properly create because they were attempting to create in us-east-1 and not their correct region.
This appeared as a KMS key not found error, but the keys exist correctly, just not in us-east-1