### PR TITLE
fix: make deployment bucket use SSE-AES

### DIFF
--- a/infrastructure/010-aws-api/s3.tf
+++ b/infrastructure/010-aws-api/s3.tf
@@ -11,8 +11,7 @@ resource "aws_s3_bucket" "serverless_code" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        sse_algorithm     = "aws:kms"
-        kms_master_key_id = data.terraform_remote_state.aws_base.outputs.terraform_cloud_iam_access_key_id
+        sse_algorithm = "AES256"
       }
     }
   }


### PR DESCRIPTION
Closes #14

- SSE-KMS is not a good solution for cross-region deployment because s3
  & kms need to be using global keys. This is way more headache than it's
  worth.
- Switch this to AES256 so we can test using it cross-region in
  serverless locally.