### PR TITLE
chore: remove error from the cicd pipeline

### DIFF
--- a/.github/workflows/main-api.yml
+++ b/.github/workflows/main-api.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           CI: true
       - name: Serverless Deploy
-        run: yarn run sls --region=${{matrix.aws_region}} deploy --stage=prod
+        run: yarn run deploy:prod --region=${{matrix.aws_region}}
         env:
           CI: true
           AWS_ACCESS_KEY_ID: ${{ secrets.SERVERLESS_AWS_ACCESS_KEY_ID }}

--- a/api/package.json
+++ b/api/package.json
@@ -4,6 +4,7 @@
   "description": "Serverless aws-nodejs-typescript template",
   "main": "serverless.ts",
   "scripts": {
+    "deploy:prod": "sls deploy --stage=prod",
     "test": "jest"
   },
   "engines": {


### PR DESCRIPTION
Fixes #23 

- Alias the command performed by ci/cd into a package.json script
- Call the script with arguments in corrected order

