### PR TITLE
feat: add execute-api permissions to lambda

### DIFF
--- a/infrastructure/010-aws-api/iam.tf
+++ b/infrastructure/010-aws-api/iam.tf
@@ -82,3 +82,102 @@ resource "aws_iam_role_policy_attachment" "us_west_2_dynamodb" {
   role       = aws_iam_role.lambda_role.name
   policy_arn = module.us_west_2_dynamodb_table.iam_policy_dynamodb_read_write_arn
 }
+
+
+data "aws_vpc_endpoint" "us_east_1_dynamodb" {
+  vpc_id       = data.terraform_remote_state.aws_base.outputs.aws_vpc_us_east_1_vpc_id
+  service_name = "com.amazonaws.us-east-1.dynamodb"
+}
+
+data "aws_vpc_endpoint" "us_east_2_dynamodb" {
+  vpc_id       = data.terraform_remote_state.aws_base.outputs.aws_vpc_us_east_2_vpc_id
+  service_name = "com.amazonaws.us-east-2.dynamodb"
+}
+
+data "aws_vpc_endpoint" "us_west_1_dynamodb" {
+  vpc_id       = data.terraform_remote_state.aws_base.outputs.aws_vpc_us_west_1_vpc_id
+  service_name = "com.amazonaws.us-west-1.dynamodb"
+}
+
+data "aws_vpc_endpoint" "us_west_2_dynamodb" {
+  vpc_id       = data.terraform_remote_state.aws_base.outputs.aws_vpc_us_west_2_vpc_id
+  service_name = "com.amazonaws.us-west-2.dynamodb"
+}
+
+data "aws_vpc_endpoint" "us_east_1_execute_api" {
+  vpc_id       = data.terraform_remote_state.aws_base.outputs.aws_vpc_us_east_1_vpc_id
+  service_name = "com.amazonaws.us-east-1.execute-api"
+}
+
+data "aws_vpc_endpoint" "us_east_2_execute_api" {
+  vpc_id       = data.terraform_remote_state.aws_base.outputs.aws_vpc_us_east_2_vpc_id
+  service_name = "com.amazonaws.us-east-2.execute-api"
+}
+
+data "aws_vpc_endpoint" "us_west_1_execute_api" {
+  vpc_id       = data.terraform_remote_state.aws_base.outputs.aws_vpc_us_west_1_vpc_id
+  service_name = "com.amazonaws.us-west-1.execute-api"
+}
+
+data "aws_vpc_endpoint" "us_west_2_execute_api" {
+  vpc_id       = data.terraform_remote_state.aws_base.outputs.aws_vpc_us_west_2_vpc_id
+  service_name = "com.amazonaws.us-west-2.execute-api"
+}
+
+data "aws_iam_policy_document" "lambda_policy" {
+  # This policy is explicitly denied from accessing dynamodb outside of the defined VPC endpoints
+  statement {
+    effect  = "Deny"
+    actions = ["dynamodb:*"]
+    resources = [
+      module.global_dynamodb_table.dynamodb_table_arn,
+      module.us_east_1_dynamodb_table.dynamodb_table_arn,
+      module.us_east_2_dynamodb_table.dynamodb_table_arn,
+      module.us_west_1_dynamodb_table.dynamodb_table_arn,
+      module.us_west_2_dynamodb_table.dynamodb_table_arn,
+    ]
+
+    condition {
+      test     = "ForAllValues:StringNotEquals"
+      variable = "aws:sourceVpce"
+
+      values = [
+        data.aws_vpc_endpoint.us_east_1_dynamodb.id,
+        data.aws_vpc_endpoint.us_east_2_dynamodb.id,
+        data.aws_vpc_endpoint.us_west_1_dynamodb.id,
+        data.aws_vpc_endpoint.us_west_2_dynamodb.id,
+      ]
+    }
+  }
+
+  # This policy is allowed to reach the execute API for any API gateway but only through the VPC endpoints for it
+  statement {
+    effect = "Allow"
+    sid    = "LambdaPolicy"
+
+    actions = [
+      "execute-api:*",
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test     = "ForAnyValues:StringNotEquals"
+      variable = "aws:sourceVpce"
+
+      values = [
+        data.aws_vpc_endpoint.us_east_1_dynamodb.id,
+        data.aws_vpc_endpoint.us_east_2_dynamodb.id,
+        data.aws_vpc_endpoint.us_west_1_dynamodb.id,
+        data.aws_vpc_endpoint.us_west_2_dynamodb.id,
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_policy" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = data.aws_iam_policy_document.lambda_policy.json
+}


### PR DESCRIPTION
# Purpose

Add permissions to the lambda which allow it to call the API Gateway "Execute API".
This API is used for managing Websocket connections in API Gateway, including sending messages and disconnecting prematurely.

Also add a VPC endpoint for private subnets to connect to the API Gateway Execute API.