### PR TITLE
feat: give lambda dynamodb streams access

### DIFF
--- a/infrastructure/010-aws-api/iam.tf
+++ b/infrastructure/010-aws-api/iam.tf
@@ -68,6 +68,7 @@ data "aws_iam_policy_document" "lambda_dynamodb" {
     sid    = "ddb"
 
     actions = [
+      // Table and Index
       "dynamodb:BatchGetItem",
       "dynamodb:BatchWriteItem",
       "dynamodb:ConditionCheckItem",
@@ -77,6 +78,13 @@ data "aws_iam_policy_document" "lambda_dynamodb" {
       "dynamodb:Query",
       "dynamodb:Scan",
       "dynamodb:UpdateItem",
+
+      // Streams
+      "dynamodb:GetRecords",
+      "dynamodb:GetShardIterator",
+      "dynamodb:DescribeStream",
+      "dynamodb:ListShards",
+      "dynamodb:ListStreams",
     ]
 
     resources = concat(
@@ -85,6 +93,7 @@ data "aws_iam_policy_document" "lambda_dynamodb" {
       module.us_east_2_dynamodb_table.iam_policy_arns,
       module.us_west_1_dynamodb_table.iam_policy_arns,
       module.us_west_2_dynamodb_table.iam_policy_arns,
+      ["arn:aws:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/${module.global_dynamodb_table.dynamodb_table_id}/stream/*"],
     )
 
     condition {


### PR DESCRIPTION
# Purpose

To give lambda permissions to read dynamodb stream trigger events, for the onchange callback to run.